### PR TITLE
Add support for --auto-decompress-gz option

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,7 @@ edition = "2021"
 anyhow = "1.0.86"
 brotli = "6.0.0"
 clap = { version = "4.5.16", features = ["derive"] }
+flate2 = "1.0.32"
 serde_json = "1.0.125"
 tar = "0.4.41"
+tempfile = "3.12.0"


### PR DESCRIPTION
When this option is given any file that ends with ".gz" is automatically decompressed before added to the (compressed) archive.

This can give a substantial improvement in compression rates. Not only because brotli is a better compressor than gzip; if the different decompressed .gz files are similar brotli can also see the redundancy across the different files.